### PR TITLE
Add AU script

### DIFF
--- a/_scripts/Get-MsiDatabaseVersion.ps1
+++ b/_scripts/Get-MsiDatabaseVersion.ps1
@@ -1,0 +1,37 @@
+﻿function Get-MsiDatabaseVersion {
+    param (
+        [string] $fn
+    )
+
+    try {
+        $FullPath = (Resolve-Path $fn).Path
+        $windowsInstaller = New-Object -com WindowsInstaller.Installer
+
+        $database = $windowsInstaller.GetType().InvokeMember(
+                "OpenDatabase", "InvokeMethod", $Null, 
+                $windowsInstaller, @($FullPath, 0)
+            )
+
+        $q = "SELECT Value FROM Property WHERE Property = 'ProductVersion'"
+        $View = $database.GetType().InvokeMember(
+                "OpenView", "InvokeMethod", $Null, $database, ($q)
+            )
+
+        $View.GetType().InvokeMember("Execute", "InvokeMethod", $Null, $View, $Null)
+
+        $record = $View.GetType().InvokeMember(
+                "Fetch", "InvokeMethod", $Null, $View, $Null
+            )
+
+        $productVersion = $record.GetType().InvokeMember(
+                "StringData", "GetProperty", $Null, $record, 1
+            )
+
+        $View.GetType().InvokeMember("Close", "InvokeMethod", $Null, $View, $Null)
+
+        return $productVersion
+
+    } catch {
+        throw "Failed to get MSI file version the error was: {0}." -f $_
+    }
+}

--- a/_scripts/Update-OnETagChanged.ps1
+++ b/_scripts/Update-OnETagChanged.ps1
@@ -1,0 +1,50 @@
+# NOTE: No documentation will be written for this script.
+# This is only a temporary script until a generic version
+# have been added to the wormies-au-helpers powershell package
+
+function Update-OnETagChanged() {
+  param(
+    [uri]$execUrl,
+    [string]$saveFile = ".{0}info" -f [IO.Path]::DirectorySeparatorChar,
+    [scriptblock]$OnETagChanged,
+    [scriptblock]$OnUpdated
+  )
+
+  $request = [System.Net.WebRequest]::CreateDefault($execUrl)
+
+  try {
+    $response = $request.GetResponse()
+    $etag = $response.Headers.Get("ETag")
+  }
+  finally {
+    $response.Dispose()
+    $response = $null
+  }
+
+  $saveResult = $false
+  if (!(Test-Path $saveFile) -or ($global:au_Force -eq $true)) {
+    $result = . $OnETagChanged
+    $saveResult = $true
+  }
+  else {
+    $existingInfo = (Get-Content $saveFile -Encoding UTF8 -TotalCount 1) -split '\|'
+
+    if ($existingInfo[0] -ne $etag) {
+      $result = . $OnETagChanged
+      $saveResult = $true
+    }
+    else {
+      $result = . $OnUpdated
+      $result["Version"] = $existingInfo[1]
+      $result["ETAG"] = $existingInfo[0]
+      $saveResult = $false
+    }
+  }
+
+  if ($saveResult) {
+    $result["ETAG"] = $etag
+    "$($result["ETAG"])|$($result["Version"])" | Out-File $saveFile -Encoding utf8 -NoNewline
+  }
+
+  return $result
+}

--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,52 @@
+Import-Module AU
+Import-Module $([System.IO.Path]::Combine($env:ChocolateyInstall, 'helpers', 'chocolateyInstaller.psm1'))
+. $([System.IO.Path]::Combine('_scripts', 'Update-OnETagChanged.ps1'))
+. $([System.IO.Path]::Combine('_scripts', 'Get-MsiDatabaseVersion.ps1'))
+
+$downloads = 'https://clients.amazonworkspaces.com/'
+
+function global:au_BeforeUpdate() {
+  $Latest.Checksum32 = Get-RemoteChecksum $Latest.Url32
+}
+
+function global:au_SearchReplace {
+    @{
+        "tools\chocolateyinstall.ps1" = @{    
+            "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+            "(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.Url32)'"
+		}
+	}
+}
+
+function GetResultInformation([string]$url32) {
+  $fileName = Split-path -Leaf $url32
+  $dest = $([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), $((new-guid).guid), $fileName))
+
+  Get-WebFile $url32 $dest
+
+  if ($isLinux) {
+      $version = & msiinfo export $dest Property | grep ProductVersion | cut -c 16-
+  } else {
+      $version = ([string](Get-MsiDatabaseVersion $dest)).trim()
+  }
+
+  return @{
+    URL32          = $url32
+    Version        = $version
+    RemoteVersion  = $version
+    FileName32     = $fileName
+  }
+}
+
+function global:au_GetLatest {
+    $downloads_page = Invoke-WebRequest -UseBasicParsing -Uri $downloads
+    $url32          = $downloads_page.links | ? href -match ".*\.msi" | select -First 1 -expand href
+    
+    $result = Update-OnETagChanged -execUrl $url32 -OnEtagChanged {
+        GetResultInformation $url32
+    } -OnUpdated { @{ URL32 = $url32 } }
+
+    return $result
+}
+
+Update-Package -ChecksumFor none


### PR DESCRIPTION
Due to how AU is written, this requires the folder to be named `amazon-workspaces` and not `choco-amazon-workspaces`. 

It will create a file called `info` with the etag of the download url and the software version. That allows a "caching" of the results, so it only needs to be re-downloaded when the URL etag changes. This file should be committed to the repository.

As noted in `Update-OnETagChanged.ps1`, that function is still kind of hacky. See here for updates on a better one:
https://github.com/WormieCorp/Wormies-AU-Helpers/issues/13

The `GetResultInformation` has a section to work with pwsh 7 on Linux. Feel free to strip that out if you want.